### PR TITLE
Add missing dependency pyusb to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ You can install the library using pip:
 python -m pip install --upgrade pyscpi
 ```
 
+In case you intend to use the USBTMC backend the extra `usb` will also install the pyusb dependency for you:
+
+```bash
+python -m pip install pyscpi[usb]
+```
+
 ### connecting to the instrument using PyVisa
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+  "numpy",
+]
+
+[project.optional-dependencies]
+usb = ["pyusb"]
 
 [project.urls]
 "Homepage" = "https://github.com/danchitnis/pyscpi/"


### PR DESCRIPTION
pyproject.toml was missing the dependency 'pyusb' which is required for the usbtmc backend:

```
Traceback (most recent call last):
  File "test.py", line 22, in <module>
    from pyscpi import usbtmc
  File "<snip>/venv/lib/python3.10/site-packages/pyscpi/usbtmc.py", line 27, in <module>
    import usb.core
ModuleNotFoundError: No module named 'usb'
```

which was fixed by `pip3 install pyusb`.